### PR TITLE
fix ansible syntax for version_compare

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,13 +1,13 @@
 - name: Check OS version and family
   assert:
-      that: ansible_os_family == 'RedHat' and ansible_distribution_major_version | version_compare('7', '==')
+      that: ansible_os_family == 'RedHat' and ansible_distribution_major_version is version_compare('7', '==')
       msg: "This role can only be run against RHEL/CENTOS 7. {{ ansible_distribution }} {{ ansible_distribution_major_version }} is not supported."
   tags:
       - always
 
 - name: Check ansible version
   assert:
-      that: ansible_version.full | version_compare(rhel7stig_min_ansible_version, '>=')
+      that: ansible_version.full is version_compare(rhel7stig_min_ansible_version, '>=')
       msg: You must use Ansible {{ rhel7stig_min_ansible_version }} or greater
   tags:
       - always


### PR DESCRIPTION
it used to work with a `|`, but now needs to be `is`